### PR TITLE
Add ability to toggle whether day rate is hidden.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This calculates the cost of a meeting by multiplying the average day rate of the attendees by the number of them present.
 
-The timer can be paused and reset, and if you need to hide the day rate, check the button after entering the information. Checking the box can be done before or after the timer starts, but once it is checked the only way to get the day rate input back is to restart the timer (which you'd need to do anyway to start a new calculation).
+The timer can be paused and reset, and if you need to hide the day rate, check the button after entering the information. Checking the box can be done before or after the timer starts, the day rate information can be seen again by clicking the check-box again.
+
+Altering any of the values will cause the calculator to restart.
 
 [http://eleanormollett.com/meetingvalue.html](http://eleanormollett.com/meetingvalue.html)

--- a/meetingvalue.html
+++ b/meetingvalue.html
@@ -22,15 +22,16 @@
     <label for="attendees">How many people are at the meeting?</label>
     <input type="text" class="form-control input-lg" id="attendees">
   </div>
-  <div class="form-group col-sm-3 col-xs-6" id="dayRateInput" style="visibility:visible">
+  <div class="form-group col-sm-3 col-xs-6" id="dayRateInput">
     <label for="dayRate">What is the average day rate for attendees?</label>
-    <input type="text" class="form-control input-lg" id="dayRate">
+    <input type="text" class="form-control input-lg" id="dayRate" style="visibility:visible">
   </div>
 
   <div class="col-xs-12">
     <div class="col-xs-6 col-sm-3"></div>
     <div class="checkbox col-sm-3 col-xs-6" id="checkboxHidden" style="visibility:visible">
-      <label><input type="checkbox" id="dayRateHidden" name="dayRateHidden" value="hidden" onclick="hide()">Hide the day rate</label>
+<label><input type="checkbox" id="dayRateHidden" name="dayRateHidden" value="hidden" onclick="toggleDayRateVisibility()">Hide/show
+  the day rate</label>
     </div>
   </div>
 

--- a/meetingvalue.js
+++ b/meetingvalue.js
@@ -27,16 +27,14 @@ function pause(){
   clearInterval(interval);
 }
 
-function hide(){
+function toggleDayRateVisibility(){
   var checkBox = document.getElementById("dayRateHidden");
 
   var dayRateInput = document.getElementById("dayRateInput");
 
   if (checkBox.checked == true){
-    dayRateInput.style.visibility = "hidden";
-    checkboxHidden.style.visibility = "hidden"
+    dayRate.style.visibility = "hidden";
     }else{
-    dayRateInput.style.visibility = "visible";
-    checkboxHidden.style.visibility = "visible";
+    dayRate.style.visibility = "visible";
     }
   }


### PR DESCRIPTION
Hi, this change allows the user to toggle whether the day rate is shown or not - I thought it may be useful to see what day rate value was used.  

I thought this might be an interesting addition to your meeting cost calculator, happy to discuss :)